### PR TITLE
Updated to work with current Uber page format

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "q": "^1.0.1",
     "request": "^2.37.0",
     "tough-cookie": "^0.12.1",
-    "underscore": "^1.6.0"
+    "underscore": "^1.6.0",
+    "polyline": "^0.2.0"
   }
 }


### PR DESCRIPTION
@chriswhong,

This PR addresses the issue I opened earlier (#15) where the script was returning null geometries.  TL/DR - Uber changed their Map URL format, so this update makes the script compatible with the most recent https://riders.uber.com/trips page format (as of 2016-11-03).  More details in the commit messages.